### PR TITLE
Logging product inventory for orders placed with paypal

### DIFF
--- a/etc/events.xml
+++ b/etc/events.xml
@@ -22,6 +22,10 @@
         <observer name="kiwicommerce_order_place" instance="KiwiCommerce\InventoryLog\Observer\CheckoutAllSubmitAfter" />
     </event>
 
+    <event name="paypal_express_place_order_success">
+        <observer name="kiwicommerce_paypal_order_place" instance="KiwiCommerce\InventoryLog\Observer\CheckoutAllSubmitAfter" />
+    </event>
+
     <event name="sales_order_creditmemo_save_after">
         <observer name="kiwicommerce_inventory_log_credit_memo" instance="KiwiCommerce\InventoryLog\Observer\RefundOrderInventoryObserver"/>
     </event>


### PR DESCRIPTION
Paypal placed orders are not triggering the event **checkout_submit_all_after**.
Instead they are triggering **paypal_express_place_order_success** which takes the same arguments.
I've added the line in events.xml to log stock movement for Paypal orders.